### PR TITLE
wrapper for metric directionality

### DIFF
--- a/catwalk/evaluation.py
+++ b/catwalk/evaluation.py
@@ -19,64 +19,104 @@ predictions_binary (1d array-like) Binarized predictions
 labels (1d array-like) Ground truth target values
 parameters (dict) Any needed hyperparameters in the implementation
 
+All functions should be wrapped with @Metric to define the optimal direction
+
 All functions should return: (float) the resulting score
 
 Functions defined here are meant to be used in ModelEvaluator.available_metrics
 """
 
+class Metric(object):
+    """decorator for metrics: result will be a callable metric with an 
+    `optimality` parameter defined as either 'minimize' or 'maximize' 
+    depending on whether smaller or larger metric values indicate
+    better models.
+    """
 
+    def __init__(self, optimality):
+        if optimality not in ('minimize', 'maximize'):
+            raise ValueError("optimality must be 'minimize' or 'maximize'")
+        self.optimality = optimality
+
+    def __call__(self, function, *params, **kwparams):
+
+        class DecoratedMetric(object):
+            def __init__(self, optimality, function):
+                self.optimality = optimality
+                self.function = function
+                self.__name__ = function.__name__
+                self.__doc__ = function.__doc__
+            def __call__(self, *params, **kwparams):
+                return self.function(*params, **kwparams)
+
+        return DecoratedMetric(self.optimality, function)
+
+
+
+@Metric('maximize')
 def precision(_, predictions_binary, labels, parameters):
     return metrics.precision_score(labels, predictions_binary, **parameters)
 
 
+@Metric('maximize')
 def recall(_, predictions_binary, labels, parameters):
     return metrics.recall_score(labels, predictions_binary, **parameters)
 
 
+@Metric('maximize')
 def fbeta(_, predictions_binary, labels, parameters):
     return metrics.fbeta_score(labels, predictions_binary, **parameters)
 
 
+@Metric('maximize')
 def f1(_, predictions_binary, labels, parameters):
     return metrics.f1_score(labels, predictions_binary, **parameters)
 
 
+@Metric('maximize')
 def accuracy(_, predictions_binary, labels, parameters):
     return metrics.accuracy_score(labels, predictions_binary, **parameters)
 
 
+@Metric('maximize')
 def roc_auc(predictions_proba, _, labels, parameters):
     return metrics.roc_auc_score(labels, predictions_proba)
 
 
+@Metric('maximize')
 def avg_precision(predictions_proba, _, labels, parameters):
     return metrics.average_precision_score(labels, predictions_proba)
 
 
+@Metric('maximize')
 def true_positives(_, predictions_binary, labels, parameters):
      tp = [1 if x == 1 and y == 1 else 0 
              for (x, y) in zip(predictions_binary, labels)]
      return int(numpy.sum(tp))
 
 
+@Metric('minimize')
 def false_positives(_, predictions_binary, labels, parameters):
     fp = [1 if x == 1 and y == 0 else 0
             for (x, y) in zip(predictions_binary, labels)]
     return int(numpy.sum(fp))
 
 
+@Metric('maximize')
 def true_negatives(_, predictions_binary, labels, parameters):
     tn = [1 if x == 0 and y == 0 else 0
             for (x, y) in zip(predictions_binary, labels)]
     return int(numpy.sum(tn))
 
 
+@Metric('minimize')
 def false_negatives(_, predictions_binary, labels, parameters):
     fn = [1 if x == 0 and y == 1 else 0
             for (x, y) in zip(predictions_binary, labels)]
     return int(numpy.sum(fn))
 
 
+@Metric('minimize')
 def fpr(_, predictions_binary, labels, parameters):
     fp = false_positives(_, predictions_binary, labels, parameters)
     return float(fp / labels.count(0))

--- a/catwalk/evaluation.py
+++ b/catwalk/evaluation.py
@@ -1,132 +1,11 @@
 import numpy
-from sklearn import metrics
 from results_schema import Evaluation
 from catwalk.utils import db_retry, sort_predictions_and_labels
+from catwalk.metrics import *
 from sqlalchemy.orm import sessionmaker
 import logging
 import time
 
-
-"""Metric definitions
-
-Mostly just wrappers around sklearn.metrics functions, these functions
-implement a generalized interface to metric calculations that can be stored
-as a scalar in the database.
-
-All functions should take four parameters:
-predictions_proba (1d array-like) Prediction probabilities
-predictions_binary (1d array-like) Binarized predictions
-labels (1d array-like) Ground truth target values
-parameters (dict) Any needed hyperparameters in the implementation
-
-All functions should be wrapped with @Metric to define the optimal direction
-
-All functions should return: (float) the resulting score
-
-Functions defined here are meant to be used in ModelEvaluator.available_metrics
-"""
-
-class Metric(object):
-    """decorator for metrics: result will be a callable metric with an 
-    `optimality` parameter defined as either 'minimize' or 'maximize' 
-    depending on whether smaller or larger metric values indicate
-    better models.
-    """
-
-    def __init__(self, optimality):
-        if optimality not in ('minimize', 'maximize'):
-            raise ValueError("optimality must be 'minimize' or 'maximize'")
-        self.optimality = optimality
-
-    def __call__(self, function, *params, **kwparams):
-
-        class DecoratedMetric(object):
-            def __init__(self, optimality, function):
-                self.optimality = optimality
-                self.function = function
-                self.__name__ = function.__name__
-                self.__doc__ = function.__doc__
-            def __call__(self, *params, **kwparams):
-                return self.function(*params, **kwparams)
-
-        return DecoratedMetric(self.optimality, function)
-
-
-
-@Metric('maximize')
-def precision(_, predictions_binary, labels, parameters):
-    return metrics.precision_score(labels, predictions_binary, **parameters)
-
-
-@Metric('maximize')
-def recall(_, predictions_binary, labels, parameters):
-    return metrics.recall_score(labels, predictions_binary, **parameters)
-
-
-@Metric('maximize')
-def fbeta(_, predictions_binary, labels, parameters):
-    return metrics.fbeta_score(labels, predictions_binary, **parameters)
-
-
-@Metric('maximize')
-def f1(_, predictions_binary, labels, parameters):
-    return metrics.f1_score(labels, predictions_binary, **parameters)
-
-
-@Metric('maximize')
-def accuracy(_, predictions_binary, labels, parameters):
-    return metrics.accuracy_score(labels, predictions_binary, **parameters)
-
-
-@Metric('maximize')
-def roc_auc(predictions_proba, _, labels, parameters):
-    return metrics.roc_auc_score(labels, predictions_proba)
-
-
-@Metric('maximize')
-def avg_precision(predictions_proba, _, labels, parameters):
-    return metrics.average_precision_score(labels, predictions_proba)
-
-
-@Metric('maximize')
-def true_positives(_, predictions_binary, labels, parameters):
-     tp = [1 if x == 1 and y == 1 else 0 
-             for (x, y) in zip(predictions_binary, labels)]
-     return int(numpy.sum(tp))
-
-
-@Metric('minimize')
-def false_positives(_, predictions_binary, labels, parameters):
-    fp = [1 if x == 1 and y == 0 else 0
-            for (x, y) in zip(predictions_binary, labels)]
-    return int(numpy.sum(fp))
-
-
-@Metric('maximize')
-def true_negatives(_, predictions_binary, labels, parameters):
-    tn = [1 if x == 0 and y == 0 else 0
-            for (x, y) in zip(predictions_binary, labels)]
-    return int(numpy.sum(tn))
-
-
-@Metric('minimize')
-def false_negatives(_, predictions_binary, labels, parameters):
-    fn = [1 if x == 0 and y == 1 else 0
-            for (x, y) in zip(predictions_binary, labels)]
-    return int(numpy.sum(fn))
-
-
-@Metric('minimize')
-def fpr(_, predictions_binary, labels, parameters):
-    fp = false_positives(_, predictions_binary, labels, parameters)
-    return float(fp / labels.count(0))
-
-
-class UnknownMetricError(ValueError):
-    """Signifies that a metric name was passed, but no matching computation
-    function is available
-    """
-    pass
 
 
 def generate_binary_at_x(test_predictions, x_value, unit='top_n'):
@@ -212,6 +91,9 @@ class ModelEvaluator(object):
         self.db_engine = db_engine
         self.sort_seed = sort_seed or int(time.time())
         if custom_metrics:
+            for m in custom_metrics.values():
+                if not hasattr(m, 'optimality'):
+                    raise ValueError("All metrics must have an optimality parameter")
             self.available_metrics.update(custom_metrics)
         if self.db_engine:
             self.sessionmaker = sessionmaker(bind=self.db_engine)

--- a/catwalk/evaluation.py
+++ b/catwalk/evaluation.py
@@ -92,8 +92,8 @@ class ModelEvaluator(object):
         self.sort_seed = sort_seed or int(time.time())
         if custom_metrics:
             for m in custom_metrics.values():
-                if not hasattr(m, 'optimality'):
-                    raise ValueError("All metrics must have an optimality parameter")
+                if not hasattr(m, 'greater_is_better'):
+                    raise ValueError("All metrics must have a greater_is_better parameter")
             self.available_metrics.update(custom_metrics)
         if self.db_engine:
             self.sessionmaker = sessionmaker(bind=self.db_engine)

--- a/catwalk/evaluation.py
+++ b/catwalk/evaluation.py
@@ -91,12 +91,20 @@ class ModelEvaluator(object):
         self.db_engine = db_engine
         self.sort_seed = sort_seed or int(time.time())
         if custom_metrics:
-            for m in custom_metrics.values():
-                if not hasattr(m, 'greater_is_better'):
-                    raise ValueError("All metrics must have a greater_is_better parameter")
+            self._validate_metrics(custom_metrics)
             self.available_metrics.update(custom_metrics)
         if self.db_engine:
             self.sessionmaker = sessionmaker(bind=self.db_engine)
+
+    def _validate_metrics(
+        self,
+        custom_metrics
+    ):
+        for name, met in custom_metrics.items():
+            if not hasattr(met, 'greater_is_better'):
+                raise ValueError("Custom metric {} missing greater_is_better attribute".format(name))
+            elif not met.greater_is_better in (True, False):
+                raise ValueError("For custom metric {} greater_is_better must be boolean True or False".format(name))
 
     def _generate_evaluations(
         self,

--- a/catwalk/metrics.py
+++ b/catwalk/metrics.py
@@ -24,87 +24,87 @@ Functions defined here are meant to be used in ModelEvaluator.available_metrics
 
 class Metric(object):
     """decorator for metrics: result will be a callable metric with an 
-    `optimality` parameter defined as either 'minimize' or 'maximize' 
-    depending on whether smaller or larger metric values indicate
+    `greater_is_better` parameter defined as either True or False 
+    depending on whether larger or smaller metric values indicate
     better models.
     """
 
-    def __init__(self, optimality):
-        if optimality not in ('minimize', 'maximize'):
-            raise ValueError("optimality must be 'minimize' or 'maximize'")
-        self.optimality = optimality
+    def __init__(self, greater_is_better):
+        if greater_is_better not in (True, False):
+            raise ValueError("greater_is_better must be True or False")
+        self.greater_is_better = greater_is_better
 
     def __call__(self, function, *params, **kwparams):
 
         class DecoratedMetric(object):
-            def __init__(self, optimality, function):
-                self.optimality = optimality
+            def __init__(self, greater_is_better, function):
+                self.greater_is_better = greater_is_better
                 self.function = function
                 self.__name__ = function.__name__
                 self.__doc__ = function.__doc__
             def __call__(self, *params, **kwparams):
                 return self.function(*params, **kwparams)
 
-        return DecoratedMetric(self.optimality, function)
+        return DecoratedMetric(self.greater_is_better, function)
 
 
 
-@Metric('maximize')
+@Metric(greater_is_better=True)
 def precision(_, predictions_binary, labels, parameters):
     return metrics.precision_score(labels, predictions_binary, **parameters)
 
 
-@Metric('maximize')
+@Metric(greater_is_better=True)
 def recall(_, predictions_binary, labels, parameters):
     return metrics.recall_score(labels, predictions_binary, **parameters)
 
 
-@Metric('maximize')
+@Metric(greater_is_better=True)
 def fbeta(_, predictions_binary, labels, parameters):
     return metrics.fbeta_score(labels, predictions_binary, **parameters)
 
 
-@Metric('maximize')
+@Metric(greater_is_better=True)
 def f1(_, predictions_binary, labels, parameters):
     return metrics.f1_score(labels, predictions_binary, **parameters)
 
 
-@Metric('maximize')
+@Metric(greater_is_better=True)
 def accuracy(_, predictions_binary, labels, parameters):
     return metrics.accuracy_score(labels, predictions_binary, **parameters)
 
 
-@Metric('maximize')
+@Metric(greater_is_better=True)
 def roc_auc(predictions_proba, _, labels, parameters):
     return metrics.roc_auc_score(labels, predictions_proba)
 
 
-@Metric('maximize')
+@Metric(greater_is_better=True)
 def avg_precision(predictions_proba, _, labels, parameters):
     return metrics.average_precision_score(labels, predictions_proba)
 
 
-@Metric('maximize')
+@Metric(greater_is_better=True)
 def true_positives(_, predictions_binary, labels, parameters):
     return int(confusion_matrix(labels, predictions_binary)[1,1])
 
 
-@Metric('minimize')
+@Metric(greater_is_better=False)
 def false_positives(_, predictions_binary, labels, parameters):
     return int(confusion_matrix(labels, predictions_binary)[0,1])
 
 
-@Metric('maximize')
+@Metric(greater_is_better=True)
 def true_negatives(_, predictions_binary, labels, parameters):
     return int(confusion_matrix(labels, predictions_binary)[0,0])
 
 
-@Metric('minimize')
+@Metric(greater_is_better=False)
 def false_negatives(_, predictions_binary, labels, parameters):
     return int(confusion_matrix(labels, predictions_binary)[1,0])
 
 
-@Metric('minimize')
+@Metric(greater_is_better=False)
 def fpr(_, predictions_binary, labels, parameters):
     fp = false_positives(_, predictions_binary, labels, parameters)
     return float(fp / labels.count(0))

--- a/catwalk/metrics.py
+++ b/catwalk/metrics.py
@@ -1,0 +1,125 @@
+import numpy
+from sklearn import metrics
+
+
+"""Metric definitions
+
+Mostly just wrappers around sklearn.metrics functions, these functions
+implement a generalized interface to metric calculations that can be stored
+as a scalar in the database.
+
+All functions should take four parameters:
+predictions_proba (1d array-like) Prediction probabilities
+predictions_binary (1d array-like) Binarized predictions
+labels (1d array-like) Ground truth target values
+parameters (dict) Any needed hyperparameters in the implementation
+
+All functions should be wrapped with @Metric to define the optimal direction
+
+All functions should return: (float) the resulting score
+
+Functions defined here are meant to be used in ModelEvaluator.available_metrics
+"""
+
+class Metric(object):
+    """decorator for metrics: result will be a callable metric with an 
+    `optimality` parameter defined as either 'minimize' or 'maximize' 
+    depending on whether smaller or larger metric values indicate
+    better models.
+    """
+
+    def __init__(self, optimality):
+        if optimality not in ('minimize', 'maximize'):
+            raise ValueError("optimality must be 'minimize' or 'maximize'")
+        self.optimality = optimality
+
+    def __call__(self, function, *params, **kwparams):
+
+        class DecoratedMetric(object):
+            def __init__(self, optimality, function):
+                self.optimality = optimality
+                self.function = function
+                self.__name__ = function.__name__
+                self.__doc__ = function.__doc__
+            def __call__(self, *params, **kwparams):
+                return self.function(*params, **kwparams)
+
+        return DecoratedMetric(self.optimality, function)
+
+
+
+@Metric('maximize')
+def precision(_, predictions_binary, labels, parameters):
+    return metrics.precision_score(labels, predictions_binary, **parameters)
+
+
+@Metric('maximize')
+def recall(_, predictions_binary, labels, parameters):
+    return metrics.recall_score(labels, predictions_binary, **parameters)
+
+
+@Metric('maximize')
+def fbeta(_, predictions_binary, labels, parameters):
+    return metrics.fbeta_score(labels, predictions_binary, **parameters)
+
+
+@Metric('maximize')
+def f1(_, predictions_binary, labels, parameters):
+    return metrics.f1_score(labels, predictions_binary, **parameters)
+
+
+@Metric('maximize')
+def accuracy(_, predictions_binary, labels, parameters):
+    return metrics.accuracy_score(labels, predictions_binary, **parameters)
+
+
+@Metric('maximize')
+def roc_auc(predictions_proba, _, labels, parameters):
+    return metrics.roc_auc_score(labels, predictions_proba)
+
+
+@Metric('maximize')
+def avg_precision(predictions_proba, _, labels, parameters):
+    return metrics.average_precision_score(labels, predictions_proba)
+
+
+@Metric('maximize')
+def true_positives(_, predictions_binary, labels, parameters):
+     tp = [1 if x == 1 and y == 1 else 0 
+             for (x, y) in zip(predictions_binary, labels)]
+     return int(numpy.sum(tp))
+
+
+@Metric('minimize')
+def false_positives(_, predictions_binary, labels, parameters):
+    fp = [1 if x == 1 and y == 0 else 0
+            for (x, y) in zip(predictions_binary, labels)]
+    return int(numpy.sum(fp))
+
+
+@Metric('maximize')
+def true_negatives(_, predictions_binary, labels, parameters):
+    tn = [1 if x == 0 and y == 0 else 0
+            for (x, y) in zip(predictions_binary, labels)]
+    return int(numpy.sum(tn))
+
+
+@Metric('minimize')
+def false_negatives(_, predictions_binary, labels, parameters):
+    fn = [1 if x == 0 and y == 1 else 0
+            for (x, y) in zip(predictions_binary, labels)]
+    return int(numpy.sum(fn))
+
+
+@Metric('minimize')
+def fpr(_, predictions_binary, labels, parameters):
+    fp = false_positives(_, predictions_binary, labels, parameters)
+    return float(fp / labels.count(0))
+
+
+class UnknownMetricError(ValueError):
+    """Signifies that a metric name was passed, but no matching computation
+    function is available
+    """
+    pass
+

--- a/catwalk/metrics.py
+++ b/catwalk/metrics.py
@@ -86,22 +86,22 @@ def avg_precision(predictions_proba, _, labels, parameters):
 
 @Metric('maximize')
 def true_positives(_, predictions_binary, labels, parameters):
-    return confusion_matrix(labels, predictions_binary)[1,1]
+    return int(confusion_matrix(labels, predictions_binary)[1,1])
 
 
 @Metric('minimize')
 def false_positives(_, predictions_binary, labels, parameters):
-    return confusion_matrix(labels, predictions_binary)[0,1]
+    return int(confusion_matrix(labels, predictions_binary)[0,1])
 
 
 @Metric('maximize')
 def true_negatives(_, predictions_binary, labels, parameters):
-    return confusion_matrix(labels, predictions_binary)[0,0]
+    return int(confusion_matrix(labels, predictions_binary)[0,0])
 
 
 @Metric('minimize')
 def false_negatives(_, predictions_binary, labels, parameters):
-    return confusion_matrix(labels, predictions_binary)[1,0]
+    return int(confusion_matrix(labels, predictions_binary)[1,0])
 
 
 @Metric('minimize')

--- a/catwalk/metrics.py
+++ b/catwalk/metrics.py
@@ -1,5 +1,6 @@
 import numpy
 from sklearn import metrics
+from sklearn.metrics import confusion_matrix
 
 
 """Metric definitions
@@ -85,30 +86,22 @@ def avg_precision(predictions_proba, _, labels, parameters):
 
 @Metric('maximize')
 def true_positives(_, predictions_binary, labels, parameters):
-     tp = [1 if x == 1 and y == 1 else 0 
-             for (x, y) in zip(predictions_binary, labels)]
-     return int(numpy.sum(tp))
+    return confusion_matrix(labels, predictions_binary)[1,1]
 
 
 @Metric('minimize')
 def false_positives(_, predictions_binary, labels, parameters):
-    fp = [1 if x == 1 and y == 0 else 0
-            for (x, y) in zip(predictions_binary, labels)]
-    return int(numpy.sum(fp))
+    return confusion_matrix(labels, predictions_binary)[0,1]
 
 
 @Metric('maximize')
 def true_negatives(_, predictions_binary, labels, parameters):
-    tn = [1 if x == 0 and y == 0 else 0
-            for (x, y) in zip(predictions_binary, labels)]
-    return int(numpy.sum(tn))
+    return confusion_matrix(labels, predictions_binary)[0,0]
 
 
 @Metric('minimize')
 def false_negatives(_, predictions_binary, labels, parameters):
-    fn = [1 if x == 0 and y == 1 else 0
-            for (x, y) in zip(predictions_binary, labels)]
-    return int(numpy.sum(fn))
+    return confusion_matrix(labels, predictions_binary)[1,0]
 
 
 @Metric('minimize')

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -10,7 +10,7 @@ from catwalk.storage import InMemoryModelStorageEngine
 import datetime
 
 
-@Metric('maximize')
+@Metric(greater_is_better=True)
 def always_half(predictions_proba, predictions_binary, labels, parameters):
     return 0.5
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,4 +1,5 @@
 from catwalk.evaluation import ModelEvaluator, generate_binary_at_x
+from catwalk.metrics import Metric
 import testing.postgresql
 
 import numpy
@@ -9,6 +10,7 @@ from catwalk.storage import InMemoryModelStorageEngine
 import datetime
 
 
+@Metric('maximize')
 def always_half(predictions_proba, predictions_binary, labels, parameters):
     return 0.5
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,4 +1,4 @@
-from catwalk.evaluation import ModelEvaluator, generate_binary_at_x, fpr
+from catwalk.evaluation import ModelEvaluator, generate_binary_at_x
 import testing.postgresql
 
 import numpy
@@ -166,13 +166,3 @@ def test_generate_binary_at_x():
         [1, 1, 0, 0, 0, 0, 0, 0, 0, 0]
 
 
-def test_fpr():
-    predictions_binary = \
-        [1, 1, 1, 0, 0, 0, 0, 0]
-    labels = \
-        [1, 1, 0, 1, 0, 0, 0, 1]
-
-    result = fpr([], predictions_binary, labels, [])
-    # false positives = 1
-    # total negatives = 4
-    assert result == 0.25

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,25 @@
+from catwalk.metrics import fpr
+from catwalk.evaluation import ModelEvaluator
+
+def test_metric_directionality():
+    """All metrics must be wrapped using the @Metric decorator available
+    in catwalk.metrics to provide an `optimality` attribute which must
+    be one of 'minimize' or 'maximize'.
+    """
+    for met in ModelEvaluator.available_metrics.values():
+        assert hasattr(met, 'optimality')
+        assert met.optimality in ('minimize', 'maximize')
+
+
+def test_fpr():
+    predictions_binary = \
+        [1, 1, 1, 0, 0, 0, 0, 0]
+    labels = \
+        [1, 1, 0, 1, 0, 0, 0, 1]
+
+    result = fpr([], predictions_binary, labels, [])
+    # false positives = 1
+    # total negatives = 4
+    assert result == 0.25
+
+

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -3,12 +3,12 @@ from catwalk.evaluation import ModelEvaluator
 
 def test_metric_directionality():
     """All metrics must be wrapped using the @Metric decorator available
-    in catwalk.metrics to provide an `optimality` attribute which must
-    be one of 'minimize' or 'maximize'.
+    in catwalk.metrics to provide an `greater_is_better` attribute which must
+    be one of True or False.
     """
     for met in ModelEvaluator.available_metrics.values():
-        assert hasattr(met, 'optimality')
-        assert met.optimality in ('minimize', 'maximize')
+        assert hasattr(met, 'greater_is_better')
+        assert met.greater_is_better in (True, False)
 
 
 def test_fpr():


### PR DESCRIPTION
Adds a `Metric` decorator to allow metrics to keep track of which direction indicates better results. When using the decorator, the `optimality` parameter must be specified as either 'minimize' (that is, smaller values of the metric are better, such as for fpr) or 'maximize' (larger values are better, as in precision or recall).

The primary use case here is to allow model selection methods to determine whether how they should compare several models with respect to a given metric.

Also, I'm not sure if `optimality` is the best naming here but nothing seemed great. We could go with `greater_is_better` as in the sklearn's [make_scorer](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.make_scorer.html#sklearn.metrics.make_scorer) for grid searching, but that feels a bit wordy.