### PR TITLE
Fix import in feature_importances [Resolves #13]

### DIFF
--- a/catwalk/feature_importances.py
+++ b/catwalk/feature_importances.py
@@ -2,7 +2,7 @@ import warnings
 
 import numpy as np
 
-import sklearn
+import sklearn.linear_model
 
 def _ad_hoc_feature_importances(model):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyYAML
 psycopg2
 python-dateutil
 scipy
-sklearn
+sklearn==0.18.2
 tables==3.3.0
 pandas
 boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PyYAML
 psycopg2
 python-dateutil
 scipy
-sklearn==0.18.2
+scikit-learn==0.18.2
 tables==3.3.0
 pandas
 boto3


### PR DESCRIPTION
If sklearn.linear_model isn't already imported, the line in question will fail even if sklearn is imported at the top of the file. This was hidden because the test has to import sklearn.linear_model in order to create the model we're testing. Although it's very hard to add a test that catches this, this change should fix the bug.