### PR TITLE
supporting dummy classifier and linear kernel svc

### DIFF
--- a/catwalk/feature_importances.py
+++ b/catwalk/feature_importances.py
@@ -3,6 +3,7 @@ import warnings
 import numpy as np
 
 import sklearn.linear_model
+from sklearn.svm import SVC
 
 def _ad_hoc_feature_importances(model):
     """
@@ -26,7 +27,7 @@ def _ad_hoc_feature_importances(model):
         #intercept_odds_ratio = np.exp(model.intercept_[:,np.newaxis])
         ## We are ignoring the intercept
 
-        ## NOTE: We need to squeeze this array so it have the correct dimensions
+        ## NOTE: We need to squeeze this array so it has the correct dimensions
         feature_importances = coef_odds_ratio.squeeze()
 
     return feature_importances
@@ -41,11 +42,14 @@ def get_feature_importances(model):
     Returns:
         Feature importances, or failing that, None
     """
-
     feature_importances = None
 
     if hasattr(model, 'feature_importances_'):
         feature_importances = model.feature_importances_
+
+    elif isinstance(model, (SVC)) and (model.get_params()['kernel'] == 'linear'):
+        feature_importances = model.coef_.squeeze()
+        
     else:
         warnings.warn(
             "\nThe selected algorithm, doesn't support a standard way"


### PR DESCRIPTION
Currently, catwalk does not support sklearn's DummyClassifier because it does not have feature importances. This PR changes that by writing a row with the feature '_Algorithm does not support a standard way to calculate feature importance._' to the feature_importances table whenever we were not able to find feature importances.
For SVCs with linear kernel it also uses the coef_ attribute to get feature importances.