### PR TITLE
Individual Importances [Resolves #19]

### DIFF
--- a/catwalk/individual_importance/__init__.py
+++ b/catwalk/individual_importance/__init__.py
@@ -1,0 +1,157 @@
+from results_schema import IndividualImportance
+from catwalk.utils import save_db_objects
+import logging
+
+from .uniform import uniform_distribution
+
+
+CALCULATE_STRATEGIES = {
+    'uniform': uniform_distribution
+}
+
+
+class IndividualImportanceCalculator(object):
+    """Calculates and saves individual importance scores and rankings using different methods
+
+    Args:
+        db_engine (sqlalchemy.engine)
+        n_ranks (int) Number of ranks to calculate and save. Defaults to 5
+        methods (list) Strings corresponding to individual importance methods  ,
+            present in CALCULATE_STRATEGIES that should be called.
+            Defaults to ['uniform']
+        replace (bool) Whether to replace old records or reuse them.
+    """
+    def __init__(
+        self,
+        db_engine,
+        n_ranks=5,
+        methods=['uniform'],
+        replace=True
+    ):
+        self.db_engine = db_engine
+        self.n_ranks = n_ranks
+        self.methods = methods
+        self.replace = replace
+
+    def _num_existing_importances(self, model_id, as_of_date, method):
+        return [row[0] for row in self.db_engine.execute(
+            '''select count(*) from results.individual_importances
+            where model_id = %s
+            and as_of_date = %s
+            and method = %s''',
+            model_id, as_of_date, method)][0]
+
+    def _needs_new_importances(self, model_id, as_of_date, method, matrix_store):
+        """Determines whether or not importances matching the arguments are present in the database
+
+        To do this, we check how many importances exist for the given arguments
+        and compare with the number of importances that the given matrix will produce.
+
+        Args:
+            model_id (int) A model id, expected to be present in results.models
+            as_of_date (datetime or string) The date to produce individual importances as of
+            method (string) The name of a method to use to produce individual importances
+            matrix_store (catwalk.storage.MatrixStore) The test matrix
+
+        Returns: (bool) whether or not there are fewer importances in the db than the matrix
+        """
+        existing_importances = self._num_existing_importances(
+            model_id,
+            as_of_date,
+            method
+        )
+        expected_importances = matrix_store.num_entities * self.n_ranks
+        logging.debug(
+            'model_id=%s/as_of_date=%s/method=%s: found %s importances',
+            model_id, as_of_date, method, existing_importances
+        )
+        logging.debug(
+            'matrix_uuid=%s/n_ranks=%s: expect %s importances',
+            matrix_store.uuid, expected_importances
+        )
+        return existing_importances < expected_importances
+
+    def calculate_and_save_all_methods_and_dates(self, model_id, test_matrix_store):
+        """Calculate and save individual importances for the given model and test matrix
+
+        Args:
+            model_id (int) A model id, expected to be present in results.models
+            test_matrix_store (catwalk.storage.MatrixStore) The test matrix
+        """
+        for method in self.methods:
+            for as_of_date in test_matrix_store.as_of_dates:
+                self.calculate_and_save(model_id, test_matrix_store, method, as_of_date)
+
+    def calculate_and_save(
+        self,
+        model_id,
+        test_matrix_store,
+        method,
+        as_of_date
+    ):
+        """Calculate and save importances for a given model, test matrix, method, and date
+
+        Args:
+            model_id (int) A model id, expected to be present in results.models
+            test_matrix_store (catwalk.storage.MatrixStore) The test matrix
+            method_name (string) The name of a method to use to produce individual importances
+                Expected to be present in CALCULATE_STRATEGIES
+            as_of_date (datetime or string) The date to produce individual importances as of
+        """
+        if not self.replace:
+            if not self._needs_new_importances(
+                model_id,
+                as_of_date,
+                method,
+                test_matrix_store
+            ):
+                logging.info('Found as many or more individual importances ' +
+                             'for model_id=%s/as_of_date=%s/method=%s, skipping',
+                             model_id, as_of_date, method)
+        else:
+            importance_records = CALCULATE_STRATEGIES[method](
+                self.db_engine,
+                model_id,
+                as_of_date,
+                test_matrix_store,
+                self.n_ranks
+            )
+            self.save(
+                importance_records=importance_records,
+                model_id=model_id,
+                as_of_date=as_of_date,
+                method_name=method
+            )
+
+    def save(self, importance_records, model_id, as_of_date, method_name):
+        """Saves computed individual feature importance records to the database.
+        Will delete any records beforehand matching the model_id, as_of_date, and method_name
+
+        Args:
+            importance_records (list) Individual importances.
+                Each entry should be a dict with keys 'entity_id' 'feature_name' and 'feature_value'
+                corresponding to the correct values for the model_id, as_of_date, and method
+            model_id (int) A model id, expected to be present in results.models
+            as_of_date (datetime or string) The as_of_date matching the importance records
+            method_name (string) The name of the method that produced the importance records
+        """
+        db_objects = []
+        self.db_engine.execute(
+            '''delete from results.individual_importances
+            where model_id = %s
+            and as_of_date = %s
+            and method = %s''',
+            model_id, as_of_date, method_name
+        )
+        for importance_record in importance_records:
+            db_object = IndividualImportance(
+                model_id=int(model_id),
+                entity_id=int(importance_record['entity_id']),
+                as_of_date=as_of_date,
+                feature=importance_record['feature_name'],
+                feature_value=importance_record['feature_value'],
+                method=method_name,
+                importance_score=float(importance_record['score']),
+            )
+            db_objects.append(db_object)
+        save_db_objects(self.db_engine, db_objects)

--- a/catwalk/individual_importance/uniform.py
+++ b/catwalk/individual_importance/uniform.py
@@ -1,0 +1,59 @@
+def _entity_feature_values(matrix, feature_name, as_of_date=None):
+    """Finds the value of the given feature for each entity in a matrix
+
+    Args:
+        matrix (pandas.DataFrame), with index either 'entity_id' or 'entity_id'/'as_of_date'
+        feature_name (string) The name of a column in the matrix
+        as_of_date (optional) If the matrix is indexed with as_of_date,
+            then this must be one of the valid as_of_dates in the matrix
+
+    Returns: (list) of (entity_id, feature_value) tuples
+    """
+    if matrix.index.names == ['entity_id']:
+        return list(zip(matrix.index.values, matrix[feature_name].tolist()))
+    elif 'entity_id' in matrix.index.names:
+        results = []
+        index_of_entity = matrix.index.names.index('entity_id')
+        index_of_date = matrix.index.names.index('as_of_date')
+        for row in zip(matrix.index.values, matrix[feature_name].tolist()):
+            index_values, feature_value = row
+            entity_id = index_values[index_of_entity]
+            if index_values[index_of_date] == as_of_date:
+                results.append((entity_id, feature_value))
+        return results
+    else:
+        return []
+
+
+def uniform_distribution(db_engine, model_id, as_of_date, test_matrix_store, n_ranks):
+    """Calculates individual feature importances based on the global feature importances
+
+    Args:
+        db_engine (sqlalchemy.engine)
+        model_id (int) A model id, expected to be present in results.models
+        as_of_date (datetime or string) The date to produce individual importances as of
+        test_matrix_store (catwalk.storage.MatrixStore) The test matrix
+        n_ranks (int) Number of ranks to calculate and save. Defaults to 5
+
+    Returns: (list) dicts with entity_id, feature_value, feature_name, score
+    """
+    global_feature_importances = [row for row in db_engine.execute(
+        '''select feature, feature_importance
+        from results.feature_importances where model_id = %s
+        order by feature_importance desc limit %s''',
+        model_id,
+        n_ranks
+    )]
+
+    results = []
+
+    for feature_name, feature_importance in global_feature_importances:
+        efv = _entity_feature_values(test_matrix_store.matrix, feature_name, as_of_date)
+        for entity_id, feature_value in efv:
+            results.append({
+                'entity_id': entity_id,
+                'feature_value': feature_value,
+                'feature_name': feature_name,
+                'score': feature_importance,
+            })
+    return results

--- a/catwalk/storage.py
+++ b/catwalk/storage.py
@@ -171,6 +171,20 @@ class MatrixStore(object):
         return self.metadata['metta-uuid']
 
 
+    @property
+    def as_of_dates(self):
+        if 'as_of_date' in self.matrix.index.names:
+            return sorted(list(set([as_of_date for entity_id, as_of_date in self.matrix.index])))
+        else:
+            return [self.metadata['end_time']]
+
+    @property
+    def num_entities(self):
+        if self.matrix.index.names == ['entity_id']:
+            return len(self.matrix.index.values)
+        elif 'entity_id' in self.matrix.index.names:
+            return len(self.matrix.index.levels[self.matrix.index.names.index('entity_id')])
+
     def matrix_with_sorted_columns(self, columns):
         columnset = set(self.columns())
         desired_columnset = set(columns)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,5 @@ inflection
 numpy>=1.12
 sqlalchemy-postgres-copy
 retrying
-results-schema
+results-schema>=1.2
 metta-data

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
     url='https://github.com/dssg/catwalk',
     packages=[
         'catwalk',
-        'catwalk.estimators'
+        'catwalk.estimators',
+        'catwalk.individual_importance'
     ],
     include_package_data=True,
     install_requires=requirements,

--- a/tests/test_individual_importance.py
+++ b/tests/test_individual_importance.py
@@ -1,0 +1,73 @@
+from catwalk.db import ensure_db
+from catwalk.individual_importance import IndividualImportanceCalculator
+from catwalk.storage import InMemoryModelStorageEngine
+from tests.utils import fake_trained_model, sample_metta_csv_diff_order
+
+import tempfile
+from sqlalchemy import create_engine
+import testing.postgresql
+from unittest.mock import patch
+
+
+def sample_individual_importance_strategy(
+    db_engine,
+    model_id,
+    as_of_date,
+    test_matrix_store,
+    n_ranks
+):
+    return [{
+        'entity_id': 1,
+        'feature_value': 0.5,
+        'feature_name': 'm_feature',
+        'score': 0.5,
+    }, {
+        'entity_id': 1,
+        'feature_value': 0.5,
+        'feature_name': 'k_feature',
+        'score': 0.5,
+    }]
+
+
+@patch.dict(
+    'catwalk.individual_importance.CALCULATE_STRATEGIES',
+    {'sample': sample_individual_importance_strategy}
+)
+def test_calculate_and_save():
+    with testing.postgresql.Postgresql() as postgresql:
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        project_path = 'econ-dev/inspections'
+        with tempfile.TemporaryDirectory() as temp_dir:
+            train_store, test_store = sample_metta_csv_diff_order(temp_dir)
+            model_storage_engine = InMemoryModelStorageEngine(project_path)
+            calculator = IndividualImportanceCalculator(db_engine, methods=['sample'])
+            # given a trained model
+            # and a test matrix
+            _, model_id = \
+                fake_trained_model(
+                    project_path,
+                    model_storage_engine,
+                    db_engine,
+                    train_matrix_uuid=train_store.uuid
+                )
+            # i expect to be able to call calculate and save
+            calculator.calculate_and_save_all_methods_and_dates(model_id, test_store)
+            # and find individual importances in the results schema afterwards
+            records = [
+                row for row in
+                db_engine.execute('''select entity_id, as_of_date
+                from results.individual_importances
+                join results.models using (model_id)''')
+            ]
+            assert len(records) > 0
+            # and that when run again, has the same result
+            calculator.calculate_and_save_all_methods_and_dates(model_id, test_store)
+            new_records = [
+                row for row in
+                db_engine.execute('''select entity_id, as_of_date
+                from results.individual_importances
+                join results.models using (model_id)''')
+            ]
+            assert len(records) == len(new_records)
+            assert records == new_records

--- a/tests/test_individual_importance_uniform.py
+++ b/tests/test_individual_importance_uniform.py
@@ -1,0 +1,86 @@
+from sqlalchemy import create_engine
+import testing.postgresql
+from results_schema.factories import ModelFactory, FeatureImportanceFactory, init_engine, session
+import pandas
+from catwalk.db import ensure_db
+from catwalk.storage import InMemoryMatrixStore
+from catwalk.individual_importance.uniform import uniform_distribution
+from tests.utils import sample_metadata
+
+
+def test_uniform_distribution_entity_id_index():
+    with testing.postgresql.Postgresql() as postgresql:
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        init_engine(db_engine)
+        model = ModelFactory()
+        feature_importances = [
+            FeatureImportanceFactory(model_rel=model, feature='feature_{}'.format(i))
+            for i in range(0, 10)
+        ]
+        data_dict = {'entity_id': [1, 2]}
+        for imp in feature_importances:
+            data_dict[imp.feature] = [0.5, 0.5]
+        test_store = InMemoryMatrixStore(
+            matrix=pandas.DataFrame.from_dict(data_dict).set_index(['entity_id']),
+            metadata=sample_metadata()
+        )
+        session.commit()
+        results = uniform_distribution(
+            db_engine,
+            model_id=model.model_id,
+            as_of_date='2016-01-01',
+            test_matrix_store=test_store,
+            n_ranks=5
+        )
+
+        assert len(results) == 10  # 5 features x 2 entities
+        for result in results:
+            assert 'entity_id' in result
+            assert 'feature_name' in result
+            assert 'score' in result
+            assert 'feature_value' in result
+            assert result['feature_value'] == 0.5
+            assert result['score'] >= 0
+            assert result['score'] <= 1
+            assert isinstance(result['feature_name'], str)
+            assert result['entity_id'] in [1, 2]
+
+
+def test_uniform_distribution_entity_date_index():
+    with testing.postgresql.Postgresql() as postgresql:
+        db_engine = create_engine(postgresql.url())
+        ensure_db(db_engine)
+        init_engine(db_engine)
+        model = ModelFactory()
+        feature_importances = [
+            FeatureImportanceFactory(model_rel=model, feature='feature_{}'.format(i))
+            for i in range(0, 10)
+        ]
+        data_dict = {'entity_id': [1, 1], 'as_of_date': ['2016-01-01', '2017-01-01']}
+        for imp in feature_importances:
+            data_dict[imp.feature] = [0.5, 0.5]
+        test_store = InMemoryMatrixStore(
+            matrix=pandas.DataFrame.from_dict(data_dict).set_index(['entity_id', 'as_of_date']),
+            metadata=sample_metadata()
+        )
+        session.commit()
+        results = uniform_distribution(
+            db_engine,
+            model_id=model.model_id,
+            as_of_date='2016-01-01',
+            test_matrix_store=test_store,
+            n_ranks=5
+        )
+
+        assert len(results) == 5  # 5 features x 1 entity for this as_of_date
+        for result in results:
+            assert 'entity_id' in result
+            assert 'feature_name' in result
+            assert 'score' in result
+            assert 'feature_value' in result
+            assert result['feature_value'] == 0.5
+            assert result['score'] >= 0
+            assert result['score'] <= 1
+            assert isinstance(result['feature_name'], str)
+            assert result['entity_id'] in [1, 2]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -157,3 +157,30 @@ class MatrixStoreTest(unittest.TestCase):
                     )\
                     .values\
                     .tolist()
+
+    def test_as_of_dates_entity_index(self):
+        data = {
+            'entity_id': [1, 2],
+            'feature_one': [0.5, 0.6],
+            'feature_two': [0.5, 0.6],
+        }
+        matrix = InMemoryMatrixStore(
+            matrix=pandas.DataFrame.from_dict(data),
+            metadata={'end_time': '2016-01-01', 'indices': ['entity_id']}
+        )
+
+        self.assertEqual(matrix.as_of_dates, ['2016-01-01'])
+
+    def test_as_of_dates_entity_date_index(self):
+        data = {
+            'entity_id': [1, 2, 1, 2],
+            'feature_one': [0.5, 0.6, 0.5, 0.6],
+            'feature_two': [0.5, 0.6, 0.5, 0.6],
+            'as_of_date': ['2016-01-01', '2016-01-01', '2017-01-01', '2017-01-01']
+        }
+        matrix = InMemoryMatrixStore(
+            matrix=pandas.DataFrame.from_dict(data),
+            metadata={'indices': ['entity_id', 'as_of_date']}
+        )
+
+        self.assertEqual(matrix.as_of_dates, ['2016-01-01', '2017-01-01'])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,6 +66,17 @@ def fake_trained_model(project_path, model_storage_engine, db_engine, train_matr
     return trained_model, db_model.model_id
 
 
+def sample_metadata():
+    return {
+        'beginning_of_time': datetime.date(2015, 1, 1),
+        'end_time': datetime.date(2016, 1, 1),
+        'matrix_id': 'test_matrix',
+        'label_name': 'label',
+        'label_window': '3month',
+        'indices': ['entity_id'],
+    }
+
+
 def sample_metta_csv_diff_order(directory):
     """Stores matrix and metadata in a metta-data-like form
 


### PR DESCRIPTION
- Adds individual_importance package to handle calculation and saving or individual importances using different methods
- Adds individual_importance.uniform module to create individual importances assuming the same as the global feature importances
- Add as_of_dates and num_entities properties to storage.MatrixStore to support new individual importances
- Add save_db_objects util to handle saving of SQLAlchemy model objects using a copy command
- Pin results_schema to a version that has individual importances
- Add tests.utils.sample_metadata method to create a placeholder valid matrix metadata for tests that simple need it to exist without caring about the contents