### PR TITLE
Matrix storage

### DIFF
--- a/catwalk/storage.py
+++ b/catwalk/storage.py
@@ -111,9 +111,13 @@ class InMemoryModelStorageEngine(ModelStorageEngine):
 
 
 class MatrixStore(object):
-    _matrix = None
-    _metadata = None
     _labels = None
+
+    def __init__(self, matrix_path=None, metadata_path=None):
+        self.matrix_path = matrix_path
+        self.metadata_path = metadata_path
+        self._matrix = None
+        self._metadata = None
 
     @property
     def matrix(self):
@@ -193,11 +197,10 @@ class MatrixStore(object):
 
 
 class HDFMatrixStore(MatrixStore):
-    def __init__(self, matrix_path, metadata_path):
-        self.matrix_path = matrix_path
-        self.metadata_path = metadata_path
-        self._matrix = None
-        self._metadata = None
+    # def __init__(self, matrix=None, metadata=None):
+    #     super().__init__(self, matrix_path, metadata_path)
+    #     self._matrix = matrix
+    #     self._metadata = metadata
 
     def get_head_of_matrix(self):
         hdf = pandas.HDFStore(self.matrix_path)
@@ -208,15 +211,12 @@ class HDFMatrixStore(MatrixStore):
         self._matrix = pandas.read_hdf(self.matrix_path, mode='r+')
         with open(self.metadata_path) as f:
             self._metadata = yaml.load(f)
-            self._matrix.set_index(self.metadata['indices'], inplace=True)
+        self._matrix.set_index(self.metadata['indices'], inplace=True)
 
 
 class CSVMatrixStore(MatrixStore):
-    def __init__(self, matrix_path, metadata_path):
-        self.matrix_path = matrix_path
-        self.metadata_path = metadata_path
-        self._matrix = None
-        self._metadata = None
+    # def __init__(self):
+    #     super().__init__(self)
 
     def get_head_of_matrix(self):
         return pandas.read_csv(self.matrix_path, nrows=1)
@@ -233,3 +233,11 @@ class InMemoryMatrixStore(MatrixStore):
         self._matrix = matrix
         self._metadata = metadata
         self._labels = labels
+
+    def get_head_of_matrix(self):
+        return self.matrix.iloc[0]
+
+    @property
+    def empty(self):
+        head_of_matrix = self.get_head_of_matrix()
+        return head_of_matrix.empty

--- a/catwalk/storage.py
+++ b/catwalk/storage.py
@@ -216,7 +216,7 @@ class HDFMatrixStore(MatrixStore):
             self._metadata = yaml.load(f)
             self._matrix.set_index(self.metadata['indices'], inplace=True)
 
-class MettaCSVMatrixStore(MatrixStore):
+class CSVMatrixStore(MatrixStore):
     def __init__(self, matrix_path, metadata_path):
         self.matrix_path = matrix_path
         self.metadata_path = metadata_path

--- a/catwalk/storage.py
+++ b/catwalk/storage.py
@@ -192,12 +192,6 @@ class MatrixStore(object):
                 ''', columnset ^ desired_columnset)
 
 
-class MettaMatrixStore(MatrixStore):
-    def __init__(self, matrix_path, metadata_path):
-        self.matrix = pandas.read_hdf(matrix_path)
-        with open(metadata_path) as f:
-            self.metadata = yaml.load(f)
-
 class HDFMatrixStore(MatrixStore):
     def __init__(self, matrix_path, metadata_path):
         self.matrix_path = matrix_path
@@ -215,6 +209,7 @@ class HDFMatrixStore(MatrixStore):
         with open(self.metadata_path) as f:
             self._metadata = yaml.load(f)
             self._matrix.set_index(self.metadata['indices'], inplace=True)
+
 
 class CSVMatrixStore(MatrixStore):
     def __init__(self, matrix_path, metadata_path):

--- a/catwalk/storage.py
+++ b/catwalk/storage.py
@@ -165,7 +165,7 @@ class MatrixStore(object):
         return self.metadata['metta-uuid']
 
     def columns(self, include_label=False):
-        columns = self.matrix.columns.tolist()
+        columns = self._matrix.columns.tolist()
         if include_label:
             return columns
         else:
@@ -197,11 +197,6 @@ class MatrixStore(object):
 
 
 class HDFMatrixStore(MatrixStore):
-    # def __init__(self, matrix=None, metadata=None):
-    #     super().__init__(self, matrix_path, metadata_path)
-    #     self._matrix = matrix
-    #     self._metadata = metadata
-
     def get_head_of_matrix(self):
         hdf = pandas.HDFStore(self.matrix_path)
         key = hdf.keys()[0]
@@ -215,9 +210,6 @@ class HDFMatrixStore(MatrixStore):
 
 
 class CSVMatrixStore(MatrixStore):
-    # def __init__(self):
-    #     super().__init__(self)
-
     def get_head_of_matrix(self):
         return pandas.read_csv(self.matrix_path, nrows=1)
 
@@ -241,3 +233,9 @@ class InMemoryMatrixStore(MatrixStore):
     def empty(self):
         head_of_matrix = self.get_head_of_matrix()
         return head_of_matrix.empty
+
+    @property
+    def matrix(self):
+        if self._metadata['indices'][0] in self._matrix.columns:
+            self._matrix.set_index(self._metadata['indices'], inplace=True)
+        return self._matrix

--- a/catwalk/storage.py
+++ b/catwalk/storage.py
@@ -190,7 +190,8 @@ class HDFMatrixStore(MatrixStore):
         if not os.path.isfile(self.matrix_path):
             return True
         else:
-            return self.head_of_matrix.empty
+            head_of_matrix = self.get_head_of_matrix()
+            return head_of_matrix.empty
 
     def columns(self, include_label=False):
         head_of_matrix = self.get_head_of_matrix()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,6 +39,7 @@ def test_integration():
                 'label_window': '1y',
                 'feature_names': ['ft1', 'ft2'],
                 'metta-uuid': '1234',
+                'indices': ['entity_id'],
             }
 
             train_store = InMemoryMatrixStore(train_matrix, train_metadata)
@@ -55,12 +56,13 @@ def test_integration():
                         'feature_one': [8],
                         'feature_two': [5],
                         'label': [5]
-                    }).set_index('entity_id'),
+                    }),
                     {
                         'label_name': 'label',
                         'label_window': '1y',
                         'end_time': as_of_date,
                         'metta-uuid': '1234',
+                        'indices': ['entity_id'],
                     }
                 )
                 for as_of_date in as_of_dates

--- a/tests/test_model_trainers.py
+++ b/tests/test_model_trainers.py
@@ -48,7 +48,8 @@ def test_model_trainer():
                 'label_name': 'label',
                 'label_window': '1y',
                 'metta-uuid': '1234',
-                'feature_names': ['ft1', 'ft2']
+                'feature_names': ['ft1', 'ft2'],
+                'indices': ['entity_id'],
             }
             project_path = 'econ-dev/inspections'
             model_storage_engine = S3ModelStorageEngine(s3_conn, project_path)
@@ -72,7 +73,7 @@ def test_model_trainer():
                 row for row in
                 engine.execute('select * from results.feature_importances')
             ]
-            assert len(records) == 4 * 3  # maybe exclude entity_id?
+            assert len(records) == 4 * 2  # maybe exclude entity_id? yes
 
             records = [
                 row for row in
@@ -106,6 +107,9 @@ def test_model_trainer():
                 'feature_one': [4, 4],
                 'feature_two': [6, 5],
             })
+
+            test_matrix = InMemoryMatrixStore(matrix=test_matrix, metadata=metadata).matrix
+
             for model_pickle in model_pickles:
                 predictions = model_pickle.predict(test_matrix)
                 assert len(predictions) == 2
@@ -142,7 +146,7 @@ def test_model_trainer():
                 row for row in
                 engine.execute('select * from results.feature_importances')
             ]
-            assert len(records) == 4 * 3  # maybe exclude entity_id?
+            assert len(records) == 4 * 2  # maybe exclude entity_id? yes
 
             # 7. if the cache is missing but the metadata is still there, reuse the metadata
             for row in engine.execute('select model_hash from results.models'):
@@ -207,7 +211,8 @@ def test_n_jobs_not_new_model():
                     'beginning_of_time': datetime.date(2012, 12, 20),
                     'label_name': 'label',
                     'metta-uuid': '1234',
-                    'feature_names': ['ft1', 'ft2']
+                    'feature_names': ['ft1', 'ft2'],
+                    'indices': ['entity_id'],
                 })
             )
             assert len(train_tasks) == 35 # 32+3, would be (32*2)+3 if we didn't remove
@@ -237,7 +242,7 @@ class RetryTest(unittest.TestCase):
         trainer = None
         # set up a basic model training run
         # TODO abstract the setup of a basic model training run where
-        # we don't worry about the specific values used? it would make 
+        # we don't worry about the specific values used? it would make
         # tests like this require a bit less noise to read past
         with testing.postgresql.Postgresql() as postgresql:
             engine = create_engine(postgresql.url())
@@ -262,7 +267,8 @@ class RetryTest(unittest.TestCase):
                 'beginning_of_time': datetime.date(2012, 12, 20),
                 'label_name': 'label',
                 'metta-uuid': '1234',
-                'feature_names': ['ft1', 'ft2']
+                'feature_names': ['ft1', 'ft2'],
+                'indices': ['entity_id'],
             })
         # the postgres server goes out of scope here and thus no longer exists
         with patch('time.sleep') as time_mock:
@@ -306,7 +312,8 @@ class RetryTest(unittest.TestCase):
                 'beginning_of_time': datetime.date(2012, 12, 20),
                 'label_name': 'label',
                 'metta-uuid': '1234',
-                'feature_names': ['ft1', 'ft2']
+                'feature_names': ['ft1', 'ft2'],
+                'indices': ['entity_id'],
             })
 
         # start without a database server

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -49,6 +49,7 @@ def test_predictor():
                 'end_time': AS_OF_DATE,
                 'label_window': '3month',
                 'metta-uuid': '1234',
+                'indices': ['entity_id'],
             }
 
             matrix_store = InMemoryMatrixStore(matrix, metadata)
@@ -95,6 +96,7 @@ def test_predictor():
                 'end_time': AS_OF_DATE + datetime.timedelta(days=1),
                 'label_window': '3month',
                 'metta-uuid': '1234',
+                'indices': ['entity_id'],
             }
             new_matrix_store = InMemoryMatrixStore(new_matrix, new_metadata)
             predictor.predict(
@@ -146,6 +148,7 @@ def test_predictor_composite_index():
             'end_time': AS_OF_DATE,
             'label_window': '3month',
             'metta-uuid': '1234',
+            'indices': ['entity_id'],
         }
         matrix_store = InMemoryMatrixStore(matrix, metadata)
         predict_proba = predictor.predict(
@@ -235,6 +238,7 @@ def test_predictor_retrieve():
             'end_time': AS_OF_DATE,
             'label_window': '3month',
             'metta-uuid': '1234',
+            'indices': ['entity_id'],
         }
         matrix_store = InMemoryMatrixStore(matrix, metadata)
         predict_proba = predictor.predict(

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -80,8 +80,19 @@ class MatrixStoreTest(unittest.TestCase):
 
                 assert csv.matrix.to_dict() == inmemory.matrix.to_dict()
                 assert hdf.matrix.to_dict() == inmemory.matrix.to_dict()
+
                 assert csv.metadata == inmemory.metadata
                 assert hdf.metadata == inmemory.metadata
+
+                assert csv.head_of_matrix.to_dict() == inmemory.head_of_matrix.to_dict()
+                assert hdf.head_of_matrix.to_dict() == inmemory.head_of_matrix.to_dict()
+
+                assert csv.empty == inmemory.empty
+                assert hdf.empty == inmemory.empty
+
+                assert csv.labels().to_dict() == inmemory.labels().to_dict()
+                assert hdf.labels().to_dict() == inmemory.labels().to_dict()
+
 
         matrix_store = [inmemory, hdf, csv]
         return matrix_store


### PR DESCRIPTION
- Add support for HDF matrix format
- Refactor ```MatrixStore``` super class
- Remove ```MettaMatrixStore``` class
- Now `HDFMatrixStore`, `CSVMatrixStore` and `InMemoryMatrixStore` have the same methods 