### PR TITLE
Apply replace flag to Model metadata [Resolves #23]

### DIFF
--- a/catwalk/model_trainers.py
+++ b/catwalk/model_trainers.py
@@ -13,7 +13,8 @@ import numpy as np
 from catwalk.utils import \
     filename_friendly_hash, \
     retrieve_model_id_from_hash, \
-    db_retry
+    db_retry, \
+    save_db_objects
 
 from results_schema import Model, FeatureImportance
 
@@ -105,6 +106,54 @@ class ModelTrainer(object):
         return instance.fit(matrix_store.matrix, y), matrix_store.matrix.columns
 
     @db_retry
+    def _save_feature_importances(self, model_id, feature_importances, feature_names):
+        """Saves feature importances to the database.
+
+        Deletes any existing feature importances for the given model_id.
+
+        Args:
+            model_id (int) The database id for the model
+            feature_importances (numpy.ndarray, maybe). Calculated feature importances
+                for the model
+            feature_names (list) Feature names for the corresponding entries in feature_importances
+        """
+        self.db_engine.execute(
+            'delete from results.feature_importances where model_id = %s',
+            model_id
+        )
+        db_objects = []
+        if isinstance(feature_importances, np.ndarray):
+            temp_df = pandas.DataFrame({'feature_importance': feature_importances})
+            features_index = temp_df.index.tolist()
+            rankings_abs = temp_df['feature_importance'].rank(method='dense', ascending=False)
+            rankings_pct = temp_df['feature_importance'].rank(method='dense', ascending=False, pct=True)
+            for feature_index, importance, rank_abs, rank_pct in zip(
+                features_index,
+                feature_importances,
+                rankings_abs,
+                rankings_pct
+            ):
+                db_objects.append(FeatureImportance(
+                    model_id=model_id,
+                    feature_importance=round(float(importance), 10),
+                    feature=feature_names[feature_index],
+                    rank_abs=int(rank_abs),
+                    rank_pct=round(float(rank_pct), 10)
+                ))
+        # get_feature_importances was not able to find
+        # feature importances
+        else:
+            db_objects.append(FeatureImportance(
+                model_id=model_id,
+                feature_importance=0,
+                feature='Algorithm does not support a standard way' + \
+                        'to calculate feature importance.',
+                rank_abs=0,
+                rank_pct=0,
+            ))
+        save_db_objects(self.db_engine, db_objects)
+
+    @db_retry
     def _write_model_to_db(
         self,
         class_path,
@@ -119,6 +168,13 @@ class ModelTrainer(object):
         Will overwrite the data of any previous versions
         (any existing model that shares a hash)
 
+        If the replace flag on the object is set, the existing version of the model
+        will have its non-unique attributes (e.g. timestamps) updated,
+        and feature importances fully replaced.
+
+        If the replace flag on the object is not set, the existing model metadata
+        and feature importances will be used.
+
         Args:
             class_path (string) A full classpath to the model class
             parameters (dict) hyperparameters to give to the model constructor
@@ -127,63 +183,42 @@ class ModelTrainer(object):
             trained_model (object) a trained model object
             misc_db_parameters (dict) params to pass through to the database
         """
-        saved_model_id = retrieve_model_id_from_hash(self.db_engine, model_hash)
-        if saved_model_id:
-            # logging.warning('deleting existing model %s', existing_model.model_id)
-            # existing_model.delete(session)
-            # session.commit()
+        model_id = retrieve_model_id_from_hash(self.db_engine, model_hash)
+        if model_id and not self.replace:
             logging.info(
                 'Metadata for model_id %s found in database. Reusing model metadata.',
-                saved_model_id
+                model_id
             )
-            return saved_model_id
-
-        session = self.sessionmaker()
-        model = Model(
-            model_hash=model_hash,
-            model_type=class_path,
-            model_parameters=parameters,
-            model_group_id=model_group_id,
-            experiment_hash=self.experiment_hash,
-            **misc_db_parameters
-        )
-        session.add(model)
-
-        feature_importance = get_feature_importances(trained_model)
-        if isinstance(feature_importance, np.ndarray):
-            temp_df = pandas.DataFrame({'feature_importance': feature_importance})
-            features_index = temp_df.index.tolist()
-            rankings_abs = temp_df['feature_importance'].rank(method='dense', ascending=False)
-            rankings_pct = temp_df['feature_importance'].rank(method='dense', ascending=False, pct=True)
-            for feature_index, importance, rank_abs, rank_pct in zip(
-                features_index,
-                feature_importance,
-                rankings_abs,
-                rankings_pct
-            ):
-                feature_importance = FeatureImportance(
-                    model=model,
-                    feature_importance=round(float(importance), 10),
-                    feature=feature_names[feature_index],
-                    rank_abs=int(rank_abs),
-                    rank_pct=round(float(rank_pct), 10)
-                )
-                session.add(feature_importance)
-        # get_feature_importances was not able to find
-        # feature importances
+            return model_id
         else:
-            feature_importance = FeatureImportance(
-                model=model,
-                feature_importance=0,
-                feature='Algorithm does not support a standard way' + \
-                        'to calculate feature importance.',
-                rank_abs=0,
-                rank_pct=0,
+            model = Model(
+                model_hash=model_hash,
+                model_type=class_path,
+                model_parameters=parameters,
+                model_group_id=model_group_id,
+                experiment_hash=self.experiment_hash,
+                **misc_db_parameters
             )
-            session.add(feature_importance)
-        session.commit()
-        model_id = model.model_id
-        session.close()
+            session = self.sessionmaker()
+            if model_id:
+                logging.info('Found model id %s, updating non-unique attributes', model_id)
+                model.model_id = model_id
+                session.merge(model)
+                session.commit()
+            else:
+                session.add(model)
+                session.commit()
+                model_id = model.model_id
+                logging.info('Added new model id %s', model_id)
+            session.close()
+
+        logging.info('Saving feature importances for model_id %s', model_id)
+        self._save_feature_importances(
+            model_id,
+            get_feature_importances(trained_model),
+            feature_names
+        )
+        logging.info('Done saving feature importances for model_id %s', model_id)
         return model_id
 
     def _train_and_store_model(


### PR DESCRIPTION
At present, the replace flag has no effect on model metadata, only the model pickle file.
This is problematic, as something may have changed even if
the model hashes to the same model id, such as the source data. The replace flag is meant to
signal this, so any new data should be used.

The new behavior for 'replace' is this: the non-unique attributes, like timestamps, are updated on the model row.
Furthermore, feature importances are deleted and the new ones inserted in place.

There is some refactoring here that takes advantage of a new utility function available.
save_db_objects uses a COPY command to save SQLAlchemy database objects quickly and without requiring a Session.
Since many feature importance records might be written at one time when saving a model, this is used. A Session is still
used for adding/updating the model object itself, as using a COPY command for one row would have minimal utility and
the Session provides much more value (model_id autogeneration, and easy updating of the row without constructing a large SQL query)