### PR TITLE
Open smartly [Resolves #22]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,4 @@ retrying
 results-schema>=1.2
 metta-data
 smart_open
-moto
 boto

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ retrying
 results-schema>=1.2
 metta-data
 smart_open
+moto
+boto

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ sqlalchemy-postgres-copy
 retrying
 results-schema>=1.2
 metta-data
+smart_open

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,4 @@ pytest==3.0.7
 codecov==2.0.9
 pytest-cov==2.5.1
 testing.postgresql==1.3.0
-moto
+moto==1.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,4 +7,4 @@ pytest==3.0.7
 codecov==2.0.9
 pytest-cov==2.5.1
 testing.postgresql==1.3.0
-moto<1.0
+moto

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,12 +1,13 @@
 from catwalk.storage import S3Store, FSStore, MemoryStore, InMemoryMatrixStore, HDFMatrixStore, CSVMatrixStore
-from moto import mock_s3
 import tempfile
-import boto3
 import os
 import pandas
 from collections import OrderedDict
 import unittest
 import yaml
+import boto
+import smart_open
+from moto import mock_s3, mock_s3_deprecated
 
 class SomeClass(object):
     def __init__(self, val):
@@ -14,6 +15,7 @@ class SomeClass(object):
 
 
 def test_S3Store():
+    import boto3
     with mock_s3():
         s3_conn = boto3.resource('s3')
         s3_conn.create_bucket(Bucket='a-bucket')
@@ -184,3 +186,26 @@ class MatrixStoreTest(unittest.TestCase):
         )
 
         self.assertEqual(matrix.as_of_dates, ['2016-01-01', '2017-01-01'])
+
+    def test_s3_save(self):
+        with mock_s3_deprecated():
+            s3_conn = boto.connect_s3()
+            bucket_name = 'fake-matrix-bucket'
+            bucket = s3_conn.create_bucket(bucket_name)
+
+
+            matrix_store_list = self.matrix_store()
+
+            for matrix_store in matrix_store_list:
+                matrix_store.save(project_path='s3://fake-matrix-bucket', name='test')
+
+            # HDF
+            hdf = HDFMatrixStore(matrix_path='s3://fake-matrix-bucket/test.h5', metadata_path='s3://fake-matrix-bucket/test.yaml')
+
+            # CSV
+            csv = CSVMatrixStore(matrix_path='s3://fake-matrix-bucket/test.csv', metadata_path='s3://fake-matrix-bucket/test.yaml')
+
+            assert csv.metadata == matrix_store_list[0].metadata
+            assert csv.matrix.to_dict() == matrix_store_list[0].matrix.to_dict()
+            assert hdf.metadata == matrix_store_list[0].metadata
+            assert hdf.matrix.to_dict() == matrix_store_list[0].matrix.to_dict()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -76,7 +76,7 @@ class MatrixStoreTest(unittest.TestCase):
             with open(tmpyaml, 'w') as outfile:
                 yaml.dump(metadata, outfile, default_flow_style=False)
                 df.to_csv(tmpcsv, index=False)
-                df.to_hdf(tmphdf, 'test')
+                df.to_hdf(tmphdf, 'matrix')
                 csv = CSVMatrixStore(matrix_path=tmpcsv, metadata_path=tmpyaml)
                 hdf = HDFMatrixStore(matrix_path=tmphdf, metadata_path=tmpyaml)
 
@@ -201,7 +201,6 @@ class MatrixStoreTest(unittest.TestCase):
 
             # HDF
             hdf = HDFMatrixStore(matrix_path='s3://fake-matrix-bucket/test.h5', metadata_path='s3://fake-matrix-bucket/test.yaml')
-
             # CSV
             csv = CSVMatrixStore(matrix_path='s3://fake-matrix-bucket/test.csv', metadata_path='s3://fake-matrix-bucket/test.yaml')
 


### PR DESCRIPTION
- Now all storage classes can take s3 path as input by using smart_open package. For example, 
`hdf = storage.HDFMatrixStore(matrix_path='s3://fake-matrix-bucket/test.h5', metadata_path='s3://fake-matrix-bucket/test.yaml')`
or `csv = storage.CSVMatrixStore(matrix_path='s3://accessID:Password@fake-matrix-bucket/test.csv', metadata_path='s3://accessID:Password@fake-matrix-bucket/test.yaml'` if we have accessID and password.

- Noted that pandas.read_hdf() and pandas.DataFrame.to_hdf() don't support generic generic buffers, so I implemented two support functions `_read_hdf_from_buffer` and `_write_hdf_to_buffer` to handle hdf file.