### PR TITLE
Classifiers that respect categoricals

### DIFF
--- a/catwalk/estimators/classifiers.py
+++ b/catwalk/estimators/classifiers.py
@@ -102,7 +102,7 @@ class CatInATreeClassifier(BaseEstimator, ClassifierMixin):
                  min_samples_leaf=1,
                  min_weight_fraction_leaf=0.,
                  max_leaf_nodes=None,
-                 min_impurity_split=None,
+                 min_impurity_split=1e-07,
                  class_weight=None,
                  presort=False):
 
@@ -187,7 +187,7 @@ class CatInAForestClassifier(BaggingClassifier):
         n_estimators=10, max_samples=1.0, bootstrap=True, oob_score=False, 
         warm_start=False, n_jobs=1, verbose=0, criterion="gini", splitter="best", 
         max_depth=None, min_samples_split=2, min_samples_leaf=1, 
-        min_weight_fraction_leaf=0., max_leaf_nodes=None, min_impurity_split=None, 
+        min_weight_fraction_leaf=0., max_leaf_nodes=None, min_impurity_split=1e-07, 
         class_weight=None, presort=False):
 
         # set up the base estimator as a CatInATreeClassifier()

--- a/catwalk/estimators/classifiers.py
+++ b/catwalk/estimators/classifiers.py
@@ -102,7 +102,6 @@ class CatInATreeClassifier(BaseEstimator, ClassifierMixin):
                  min_samples_leaf=1,
                  min_weight_fraction_leaf=0.,
                  max_leaf_nodes=None,
-                 min_impurity_decrease=0.,
                  min_impurity_split=None,
                  class_weight=None,
                  presort=False):
@@ -117,7 +116,6 @@ class CatInATreeClassifier(BaseEstimator, ClassifierMixin):
         self.max_features = max_features
         self.random_state = random_state
         self.max_leaf_nodes = max_leaf_nodes
-        self.min_impurity_decrease = min_impurity_decrease
         self.min_impurity_split = min_impurity_split
         self.class_weight = class_weight
         self.presort = presort
@@ -127,8 +125,7 @@ class CatInATreeClassifier(BaseEstimator, ClassifierMixin):
             criterion=criterion, splitter=splitter, max_depth=max_depth, min_samples_split=min_samples_split,
             min_samples_leaf=min_samples_leaf, min_weight_fraction_leaf=min_weight_fraction_leaf,
             max_features=1.0, random_state=random_state, max_leaf_nodes=max_leaf_nodes,
-            min_impurity_decrease=min_impurity_decrease, min_impurity_split=min_impurity_split,
-            class_weight=class_weight, presort=presort
+            min_impurity_split=min_impurity_split, class_weight=class_weight, presort=presort
         )
 
         self.pipeline = Pipeline([
@@ -190,8 +187,8 @@ class CatInAForestClassifier(BaggingClassifier):
         n_estimators=10, max_samples=1.0, bootstrap=True, oob_score=False, 
         warm_start=False, n_jobs=1, verbose=0, criterion="gini", splitter="best", 
         max_depth=None, min_samples_split=2, min_samples_leaf=1, 
-        min_weight_fraction_leaf=0., max_leaf_nodes=None, min_impurity_decrease=0., 
-        min_impurity_split=None, class_weight=None, presort=False):
+        min_weight_fraction_leaf=0., max_leaf_nodes=None, min_impurity_split=None, 
+        class_weight=None, presort=False):
 
         # set up the base estimator as a CatInATreeClassifier()
         self.base_estimator = CatInATreeClassifier(
@@ -199,8 +196,7 @@ class CatInAForestClassifier(BaggingClassifier):
             criterion=criterion, splitter=splitter, max_depth=max_depth, 
             min_samples_split=min_samples_split, min_samples_leaf=min_samples_leaf, 
             min_weight_fraction_leaf=min_weight_fraction_leaf, max_leaf_nodes=max_leaf_nodes, 
-            min_impurity_decrease=min_impurity_decrease, min_impurity_split=min_impurity_split,
-            class_weight=class_weight, presort=presort
+            min_impurity_split=min_impurity_split, class_weight=class_weight, presort=presort
             )
 
         # Call the super-class's constructor
@@ -233,7 +229,6 @@ class CatInAForestClassifier(BaggingClassifier):
         self.min_samples_leaf = min_samples_leaf
         self.min_weight_fraction_leaf = min_weight_fraction_leaf
         self.max_leaf_nodes = max_leaf_nodes
-        self.min_impurity_decrease = min_impurity_decrease
         self.min_impurity_split = min_impurity_split
         self.class_weight = class_weight
         self.presort = presort

--- a/catwalk/estimators/classifiers.py
+++ b/catwalk/estimators/classifiers.py
@@ -4,8 +4,10 @@ from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.linear_model import LogisticRegression
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.ensemble import BaggingClassifier
 
-from catwalk.estimators.transformers import CutOff
+from catwalk.estimators.transformers import CutOff, SubsetWithCategoricals
 
 class ScaledLogisticRegression(BaseEstimator, ClassifierMixin):
     """
@@ -76,3 +78,162 @@ class ScaledLogisticRegression(BaseEstimator, ClassifierMixin):
 
     def score(self, X, y):
         return self.pipeline.score(X,y)
+
+
+class CatInATreeClassifier(BaseEstimator, ClassifierMixin):
+    """
+    Fit a decision tree with a subset of features that respects categoricals
+
+    Args:
+        categoricals : list,
+            List of groups of column indices to be considered associated
+            with one another as categoricals. For instance [[1,2], [7,8,9]]
+            would mean columns 1 & 2 are associated as one categorical and
+            7, 8, and 9 are associated as a second one.
+    """
+    def __init__(self,
+                 categoricals,
+                 max_features='sqrt',
+                 random_state=None,
+                 criterion="gini",
+                 splitter="best",
+                 max_depth=None,
+                 min_samples_split=2,
+                 min_samples_leaf=1,
+                 min_weight_fraction_leaf=0.,
+                 max_leaf_nodes=None,
+                 min_impurity_decrease=0.,
+                 min_impurity_split=None,
+                 class_weight=None,
+                 presort=False):
+
+        self.categoricals = categoricals
+        self.criterion = criterion
+        self.splitter = splitter
+        self.max_depth = max_depth
+        self.min_samples_split = min_samples_split
+        self.min_samples_leaf = min_samples_leaf
+        self.min_weight_fraction_leaf = min_weight_fraction_leaf
+        self.max_features = max_features
+        self.random_state = random_state
+        self.max_leaf_nodes = max_leaf_nodes
+        self.min_impurity_decrease = min_impurity_decrease
+        self.min_impurity_split = min_impurity_split
+        self.class_weight = class_weight
+        self.presort = presort
+
+        self.subset_cols = SubsetWithCategoricals(categoricals=categoricals, max_features=max_features)
+        self.tree = DecisionTreeClassifier(
+            criterion=criterion, splitter=splitter, max_depth=max_depth, min_samples_split=min_samples_split,
+            min_samples_leaf=min_samples_leaf, min_weight_fraction_leaf=min_weight_fraction_leaf,
+            max_features=1.0, random_state=random_state, max_leaf_nodes=max_leaf_nodes,
+            min_impurity_decrease=min_impurity_decrease, min_impurity_split=min_impurity_split,
+            class_weight=class_weight, presort=presort
+        )
+
+        self.pipeline = Pipeline([
+            ('subset_cols', self.subset_cols),
+            ('tree', self.tree)
+        ])
+
+    def fit(self, X, y):
+
+        self.pipeline.fit(X, y)
+
+        self.max_features_ = self.pipeline.named_steps['subset_cols'].max_features_
+        self.subset_indices = self.pipeline.named_steps['subset_cols'].subset_indices
+
+        self.classes_ = self.pipeline.named_steps['tree'].classes_
+        self.n_classes_ = self.pipeline.named_steps['tree'].n_classes_
+        self.n_features_ = self.pipeline.named_steps['tree'].n_features_
+        self.n_outputs_ = self.pipeline.named_steps['tree'].n_outputs_
+        self.tree_ = self.pipeline.named_steps['tree'].tree_
+
+        # feature importances need to reference full column set but underlying tree
+        # was trained on the subset, so fill in others with zeros
+        fi = self.pipeline.named_steps['tree'].feature_importances_
+        fi_dict = dict(zip(self.subset_indices, fi))
+        fi_full = []
+        for i in range(X.shape[1]):
+            fi_full.append(fi_dict.get(i, 0))
+        self.feature_importances_ = fi_full
+
+        return self
+
+    def apply(self, X):
+        return self.pipeline.apply(X)
+
+    def decision_path(self, X):
+        return self.pipeline.decision_path(X)
+
+    def predict(self, X):
+        return self.pipeline.predict(X)
+
+    def predict_log_proba(self, X):
+        return self.pipeline.predict_log_proba(X)
+
+    def predict_proba(self, X):
+        return self.pipeline.predict_proba(X)
+
+    def score(self, X, y):
+        return self.pipeline.score(X, y)
+
+
+class CatInAForestClassifier(BaggingClassifier):
+    """
+    Bagged classifier using CatInATreeClassifiers as estimators.
+    Note that max_features is required here for the underlying
+    subsetting and that the bagging classifier will use all selected
+    features for each tree with no option for feature bootstrapping.
+    """
+    def __init__(self, categoricals, max_features_tree='sqrt', random_state=None,
+        n_estimators=10, max_samples=1.0, bootstrap=True, oob_score=False, 
+        warm_start=False, n_jobs=1, verbose=0, criterion="gini", splitter="best", 
+        max_depth=None, min_samples_split=2, min_samples_leaf=1, 
+        min_weight_fraction_leaf=0., max_leaf_nodes=None, min_impurity_decrease=0., 
+        min_impurity_split=None, class_weight=None, presort=False):
+
+        # set up the base estimator as a CatInATreeClassifier()
+        self.base_estimator = CatInATreeClassifier(
+            categoricals=categoricals, max_features=max_features_tree, random_state=random_state, 
+            criterion=criterion, splitter=splitter, max_depth=max_depth, 
+            min_samples_split=min_samples_split, min_samples_leaf=min_samples_leaf, 
+            min_weight_fraction_leaf=min_weight_fraction_leaf, max_leaf_nodes=max_leaf_nodes, 
+            min_impurity_decrease=min_impurity_decrease, min_impurity_split=min_impurity_split,
+            class_weight=class_weight, presort=presort
+            )
+
+        # Call the super-class's constructor
+        # Here, we force each tree to consider all features (without bootstrapping)
+        # as we'll handle the subsetting in the base estimator to have control over
+        # sampling categoricals. Also note that calling the BaggingClassifier
+        # constructor will set an object parameter `max_features`=1.0, so we've
+        # nammed the class parameter `max_features_tree` avoid collision.
+        BaggingClassifier.__init__(
+            self, 
+            base_estimator=self.base_estimator,
+            n_estimators=n_estimators,
+            max_samples=max_samples,
+            max_features=1.0,
+            bootstrap=bootstrap,
+            bootstrap_features=False,
+            oob_score=oob_score,
+            warm_start=warm_start,
+            n_jobs=n_jobs,
+            random_state=random_state,
+            verbose=verbose
+            )
+
+        self.categoricals = categoricals
+        self.max_features_tree = max_features_tree
+        self.criterion = criterion
+        self.splitter = splitter
+        self.max_depth = max_depth
+        self.min_samples_split = min_samples_split
+        self.min_samples_leaf = min_samples_leaf
+        self.min_weight_fraction_leaf = min_weight_fraction_leaf
+        self.max_leaf_nodes = max_leaf_nodes
+        self.min_impurity_decrease = min_impurity_decrease
+        self.min_impurity_split = min_impurity_split
+        self.class_weight = class_weight
+        self.presort = presort

--- a/catwalk/estimators/transformers.py
+++ b/catwalk/estimators/transformers.py
@@ -153,7 +153,7 @@ class SubsetWithCategoricals(BaseEstimator, TransformerMixin):
 
         # this will be a mixed list of column indices for non-categoricals
         # and lists of indices for categorics
-        distinct_features = features + self.categoricals
+        distinct_features = list(non_cats) + self.categoricals
 
         self.max_features_ = self._infer_max_features(len(distinct_features))
         if self.max_features_ > len(distinct_features):

--- a/catwalk/estimators/transformers.py
+++ b/catwalk/estimators/transformers.py
@@ -3,10 +3,25 @@
 import warnings
 
 import numpy as np
+from math import log, sqrt
+import random
 
 from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.utils import check_array
 from sklearn.utils.validation import FLOAT_DTYPES
+
+def flatten_list(l):
+    """
+    Simple utility to flatten a list down to one dimension even if the list
+    contains elements of differing depth
+    """
+    res = []
+    for i in l:
+        if isinstance(i, list):
+            res = res + flatten_list(i)
+        else:
+            res = res + [i]
+    return res
 
 DEPRECATION_MSG_1D = (
     "Passing 1d arrays as data is deprecated in 0.17 and will "
@@ -69,3 +84,88 @@ class CutOff(BaseEstimator, TransformerMixin):
         X[X < feature_range[0]] = feature_range[0]
 
         return X
+
+
+# feels pretty gross to have to specify the categorical columns in the constructor
+# even before the object is aware of the data it's operating on, but doesn't seem
+# like the fit method is flexible enough to specify it there if we're going to 
+# use it in a pipeline. ugh.
+class SubsetWithCategoricals(BaseEstimator, TransformerMixin):
+    """
+    Subsets features of an array treating categoricals as a group
+
+    Args:
+        max_features : int, float, string or None, optional (default=None)
+            The number of features to subset down to:
+                - If int, then subset to `max_features` features.
+                - If float, then `max_features` is a percentage and
+                  `int(max_features * n_features)` features are used.
+                - If "auto", then `max_features=sqrt(n_features)`.
+                - If "sqrt", then `max_features=sqrt(n_features)`.
+                - If "log2", then `max_features=log2(n_features)`.
+                - If None, then `max_features=n_features`.
+
+        categoricals : list,
+            List of groups of column indices to be considered associated
+            with one another as categoricals. For instance [[1,2], [7,8,9]]
+            would mean columns 1 & 2 are associated as one categorical and
+            7, 8, and 9 are associated as a second one.
+
+    Attributes:
+        subset_indices : list,
+            Indices of the chosen subset of columns in the original array.
+
+        max_features_ : int,
+            The inferred value of max_features.
+    """
+    def __init__(self, categoricals, max_features='sqrt', random_state=None, copy=True):
+        self.max_features = max_features
+        self.categoricals = categoricals
+        self.copy = copy
+        if isinstance(random_state, int):
+            random.seed(random_state)
+        elif isinstance(random_state, np.random.RandomState):
+            # feels like a bit of a hack, but np doesn't seem to handle
+            # lists of mixed types so well, so using random.sample()
+            # and pretty sure this should be deterministic if a RandomState
+            # object is passed
+            random.seed(random_state.get_state()[1].sum())
+
+    def _infer_max_features(self, num_features):
+        if isinstance(self.max_features, float):
+            return int(self.max_features*num_features)
+        elif isinstance(self.max_features, int):
+            return self.max_features
+        elif self.max_features in ['auto', 'sqrt']:
+            return int(sqrt(num_features))
+        elif self.max_features == 'log2':
+            return int(log(num_features, 2))
+        elif self.max_features is None:
+            return num_features
+        else:
+            raise ValueError('Invalid value for max_features: %s' % self.max_features)
+
+    def fit(self, X, y=None):
+        features = list(range(X.shape[1]))
+
+        all_cats = set(flatten_list(self.categoricals))
+        non_cats = set(features) - all_cats
+
+        # this will be a mixed list of column indices for non-categoricals
+        # and lists of indices for categorics
+        distinct_features = features + self.categoricals
+
+        self.max_features_ = self._infer_max_features(len(distinct_features))
+        if self.max_features_ > len(distinct_features):
+            raise ValueError('Cannot subset to more than distinct features: %s vs %s' % (
+                self.max_features_, len(distinct_features)))
+
+        self.subset_indices = sorted(flatten_list(
+            random.sample(distinct_features, self.max_features_)
+        ))
+
+        return self
+
+    def transform(self, X):
+        X = check_array(X, copy=self.copy, ensure_2d=False, dtype=FLOAT_DTYPES)
+        return X[:, self.subset_indices]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -77,7 +77,8 @@ def test_integration():
                 experiment_hash=experiment_hash,
                 model_storage_engine=model_storage_engine,
                 db_engine=db_engine,
-                model_group_keys=['label_name', 'label_window']
+                model_group_keys=['label_name', 'label_window'],
+                feature_config=[]
             )
             predictor = Predictor(
                 project_path,

--- a/tests/test_model_trainers.py
+++ b/tests/test_model_trainers.py
@@ -183,11 +183,7 @@ def test_model_trainer():
 
 
 def test_model_trainer_categoricals():
-    # DELETE ME
-    pgpath = '/usr/lib/postgresql/9.6/bin/'
-    # DELETE ME
-    with testing.postgresql.Postgresql(initdb=pgpath+'initdb', postgres=pgpath+'postgres') as postgresql:
-#    with testing.postgresql.Postgresql() as postgresql:
+    with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
         ensure_db(engine)
 
@@ -296,7 +292,7 @@ def test_model_trainer_categoricals():
                 for cache_key in cache_keys
             ]
 
-            assert model_pickles[0].categoricals == [[0, 1, 2], [6, 7]]
+            assert sorted([sorted(c) for c in model_pickles[0].categoricals]) == [[0, 1, 2], [6, 7]]
 
 
 def test_n_jobs_not_new_model():

--- a/tests/test_model_trainers.py
+++ b/tests/test_model_trainers.py
@@ -57,7 +57,8 @@ def test_model_trainer():
                 experiment_hash=None,
                 model_storage_engine=model_storage_engine,
                 db_engine=engine,
-                model_group_keys=['label_name', 'label_window']
+                model_group_keys=['label_name', 'label_window'],
+                feature_config=[]
             )
             matrix_store = InMemoryMatrixStore(matrix, metadata)
             model_ids = trainer.train_models(
@@ -136,6 +137,7 @@ def test_model_trainer():
                 model_storage_engine=model_storage_engine,
                 db_engine=engine,
                 model_group_keys=['label_name', 'label_window'],
+                feature_config=[],
                 replace=True
             )
             new_model_ids = trainer.train_models(
@@ -205,7 +207,8 @@ def test_n_jobs_not_new_model():
                 experiment_hash=None,
                 model_storage_engine=S3ModelStorageEngine(s3_conn, 'econ-dev/inspections'),
                 db_engine=engine,
-                model_group_keys=['label_name', 'label_window']
+                model_group_keys=['label_name', 'label_window'],
+                feature_config=[]
             )
 
             matrix = pandas.DataFrame.from_dict({
@@ -264,7 +267,8 @@ class RetryTest(unittest.TestCase):
                 experiment_hash=None,
                 model_storage_engine=InMemoryModelStorageEngine(project_path=''),
                 db_engine=engine,
-                model_group_keys=['label_name', 'label_window']
+                model_group_keys=['label_name', 'label_window'],
+                feature_config=[]
             )
 
             matrix = pandas.DataFrame.from_dict({
@@ -309,7 +313,8 @@ class RetryTest(unittest.TestCase):
                 experiment_hash=None,
                 model_storage_engine=InMemoryModelStorageEngine(project_path=''),
                 db_engine=engine,
-                model_group_keys=['label_name', 'label_window']
+                model_group_keys=['label_name', 'label_window'],
+                feature_config=[]
             )
 
             matrix = pandas.DataFrame.from_dict({

--- a/tests/test_model_trainers.py
+++ b/tests/test_model_trainers.py
@@ -183,7 +183,11 @@ def test_model_trainer():
 
 
 def test_model_trainer_categoricals():
-    with testing.postgresql.Postgresql() as postgresql:
+    # DELETE ME
+    pgpath = '/usr/lib/postgresql/9.6/bin/'
+    # DELETE ME
+    with testing.postgresql.Postgresql(initdb=pgpath+'initdb', postgres=pgpath+'postgres') as postgresql:
+#    with testing.postgresql.Postgresql() as postgresql:
         engine = create_engine(postgresql.url())
         ensure_db(engine)
 
@@ -239,7 +243,7 @@ def test_model_trainer_categoricals():
                 'outcome': [0,1,0,0]
             })
             # ensure column order
-            matrix = matrix[['entity_id', 'as_of_date', 'first_entity_id_1y_c1_top_min', 
+            matrix = matrix[['entity_id', 'first_entity_id_1y_c1_top_min', 
                      'first_entity_id_1y_c1_bottom_min', 'first_entity_id_1y_c1__NULL_min',
                      'first_entity_id_1y_a1_sum', 'first_entity_id_1y_a2_max',
                      'second_entity_id_10y_a3_sum', 'second_entity_id_10y_c3_one_sum',


### PR DESCRIPTION
This PR creates a new pair of classifiers, `CatInATree` and `CatInAForest`, that respect categoricals when randomly sampling features. A few notes:
* To make use of these, it also adds a couple of utilities to detect columns that should be grouped together as categoricals and modifies the `_train` method of `ModelTrainer` to pass these detected column groupings.
* Note that because detecting categoricals relies on the feature config, it will fail to properly group all of the categoricals if column names are getting truncated.
* The implementation here is to simply select a random subset of features that ensure all categorical values are selected together and then train a decision tree using the entire pre-selected subset throughout (as well as using this modified decision tree in a bagging classifier). 
* It does not, however, subset the features at each node as a random forest would -- this would require a more substantial rewrite of the guts of sklearn's decision trees, but would be a useful future project.